### PR TITLE
fix: add permissions to read PRs when publishing releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,7 @@ jobs:
     runs-on: ubuntu-latest
 
     permissions:
+      pull-requests: read
       contents: write
 
     steps:


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Seeing other repo that using `changelogithub` be able to includes PRs on their release notes without any additional config feels a bit odd, in fact in my case it can only parse the commits.

This PR is basically just my assumption that this tool is need a way to read the PR related to the commits

Let see.