### PR TITLE
revert: back to `softprops/action-gh-release` as releaser tool

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,23 +20,23 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: lts/*
+      # - name: Setup Node.js
+      #   uses: actions/setup-node@v4
+      #   with:
+      #     node-version: lts/*
 
-      - name: Publish release
-        run: npx changelogithub
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      # - name: Publish release
+      #   run: npx changelogithub
+      #   env:
+      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       # - name: Read Changelog file
       #   run: npx @feryardiant/read-changelog > PUBLISH.md
 
-      # - name: Publish
-      #   uses: softprops/action-gh-release@v2
-      #   env:
-      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      #   with:
-      #     body_path: PUBLISH.md
-      #     generate_release_notes: true
+      - name: Publish
+        uses: softprops/action-gh-release@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          # body_path: PUBLISH.md
+          generate_release_notes: true


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Bsaaed on my recent attempts using `changelogithub` it purely based on commit message and cannot read PRs despite we have `pull-requests: read` permission in our workflow.

So to be able to mention a PR on release note

![Screenshot 2024-09-05 at 16 45 06](https://github.com/user-attachments/assets/9efd9509-b661-4548-87cf-94f5940f81a6)

all we need is make sure that our merge commit message is follows conventional commit format, (as far as my understanding) can ~~only be achieved by manually~~ edit the commit message when we merge the PR.

![Screenshot 2024-09-05 at 16 46 20](https://github.com/user-attachments/assets/e525da68-f06a-462c-8da5-bfabce7afaf9)

But since my objective is use pull request title as release notes, this kind of feature can be achieved by using built-in [release notes generator](https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes) that can be configured using [`release.yml`](.github/release.yml) file.

The only caviat is that tool will categorize the release notes based on PR' `labels` and the only (official) tool to assign labels to a PR can only read branch name or file changes and cannot read commit message whatsoever.

It might be counterintuitive in some cases but in this PR let's just revert back to use built-in tools to do the job.