### PR TITLE
feat: release sub packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,11 @@
       "eslint --fix"
     ]
   },
-  "standard-version": {},
+  "standard-version": {
+    "scripts": {
+      "posttag": "sh scripts/release.sh"
+    }
+  },
   "workspaces": [
     "./packages/*"
   ]

--- a/packages/bar/.github/CODEOWNERS
+++ b/packages/bar/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @feryardiant

--- a/packages/bar/.github/workflows/release.yml
+++ b/packages/bar/.github/workflows/release.yml
@@ -1,0 +1,26 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+
+jobs:
+  publish:
+    name: Publish Release
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Publish release
+        run: npx changelogithub
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+

--- a/packages/common/.github/CODEOWNERS
+++ b/packages/common/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @feryardiant

--- a/packages/common/.github/workflows/release.yml
+++ b/packages/common/.github/workflows/release.yml
@@ -1,0 +1,26 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+
+jobs:
+  publish:
+    name: Publish Release
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Publish release
+        run: npx changelogithub
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+

--- a/packages/foo/.github/CODEOWNERS
+++ b/packages/foo/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @feryardiant

--- a/packages/foo/.github/workflows/release.yml
+++ b/packages/foo/.github/workflows/release.yml
@@ -1,0 +1,26 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+
+jobs:
+  publish:
+    name: Publish Release
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Publish release
+        run: npx changelogithub
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+
+set -e
+
+SPLIT_BRANCH=main
+CURRENT_BRANCH=`git rev-parse --abbrev-ref HEAD`
+VERSION=`git describe --tags --abbrev=0`
+
+# Make sure the working directory is clear.
+if [[ "$SPLIT_BRANCH" != "$CURRENT_BRANCH" ]]; then
+    echo "Split branch ($SPLIT_BRANCH) does not match the current active branch ($CURRENT_BRANCH)." 1>&2
+
+    exit 1
+fi
+
+# Make sure the working directory is clear.
+if [[ ! -z `git status --porcelain` ]]; then
+    echo "Your working directory is dirty. Did you forget to commit your changes?" 1>&2
+
+    exit 1
+fi
+
+# Make sure latest changes are fetched first.
+git fetch origin
+
+# Make sure that release branch is in sync with origin.
+if [[ `git rev-parse HEAD` != `git rev-parse origin/$CURRENT_BRANCH` ]]; then
+    echo "Your branch is out of date with its upstream. Did you forget to pull or push any changes before releasing?" 1>&2
+
+    exit 1
+fi
+
+for pkg in `ls packages`; do
+    echo "Releasing $pkg package"
+
+    tmp_path="/tmp/monorepo-$pkg"
+
+    # Create temporary remote for the sub-package
+    git clone git@github.com:feryardiant/learn-monorepo-$pkg.git $tmp_path
+
+    cd $tmp_path
+
+    # Tagging release
+    git tag -s $VERSION -m "chore: release $VERSION"
+
+    # Push the sub-package specific branch to its remote
+    git push origin --follow-tags
+
+    # Back to main repo directory
+    cd -
+
+    echo ""
+done
+
+# Push root repository tags
+git push origin --follow-tags
+

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -33,7 +33,7 @@ fi
 for pkg in `ls packages`; do
     echo "Releasing $pkg package"
 
-    tmp_path="/tmp/monorepo-$pkg"
+    tmp_path="/tmp/monorepo/$pkg"
 
     # Create temporary remote for the sub-package
     git clone git@github.com:feryardiant/learn-monorepo-$pkg.git $tmp_path
@@ -48,6 +48,8 @@ for pkg in `ls packages`; do
 
     # Back to main repo directory
     cd -
+
+    rm -rf $tmp_path
 
     echo ""
 done

--- a/scripts/split.sh
+++ b/scripts/split.sh
@@ -7,14 +7,14 @@ CURRENT_BRANCH=`git rev-parse --abbrev-ref HEAD`
 
 # Make sure the working directory is clear.
 if [[ "$SPLIT_BRANCH" != "$CURRENT_BRANCH" ]]; then
-    echo "Split branch ($SPLIT_BRANCH) does not match the current active branch ($CURRENT_BRANCH)."
+    echo "Split branch ($SPLIT_BRANCH) does not match the current active branch ($CURRENT_BRANCH)."  1>&2
 
     exit 1
 fi
 
 # Make sure the working directory is clear.
 if [[ ! -z `git status --porcelain` ]]; then
-    echo "Your working directory is dirty. Did you forget to commit your changes?"
+    echo "Your working directory is dirty. Did you forget to commit your changes?" 1>&2
 
     exit 1
 fi
@@ -24,7 +24,7 @@ git fetch origin
 
 # Make sure that release branch is in sync with origin.
 if [[ `git rev-parse HEAD` != `git rev-parse origin/$CURRENT_BRANCH` ]]; then
-    echo "Your branch is out of date with its upstream. Did you forget to pull or push any changes before releasing?"
+    echo "Your branch is out of date with its upstream. Did you forget to pull or push any changes before releasing?" 1>&2
 
     exit 1
 fi

--- a/scripts/split.sh
+++ b/scripts/split.sh
@@ -29,7 +29,7 @@ if [[ `git rev-parse HEAD` != `git rev-parse origin/$CURRENT_BRANCH` ]]; then
     exit 1
 fi
 
-for pkg in foo bar common; do
+for pkg in `ls packages`; do
     echo "Publishing $pkg package"
 
     # Create temporary remote for the sub-package


### PR DESCRIPTION
## Tools

- [standard-version](https://github.com/conventional-changelog/standard-version)

  Yes! I know, this tool already marked as deprecated and the author also recommends another tool. But so far (at least for my needs) I can find another tool that provide the similar workflow as this one. So let's keep it as is & don't bother to use another shiny tool out there.
 
## Workflow

Personnaly I'd find a way to automate certain task if possible, but in this case for the sake of versioning a package I don't want it to be automated, the way we tag each release should be done manually by a human and than let the rest of the release process to be automated.

All I need is one command that do the following :
- Bump version number in a file, in this case is `package.json`
- Generate changelogs based on commit message and update the `CHANGELOG.md` file.
- Commit the changed files and create a signed tag.
- Loop through each sub-package and create a signed tag on each of them and than push the tag to the remote repo.
- Last one, push the main root package tag.

```mermaid
sequenceDiagram
    participant A as User
    participant B as Standard-Version
    participant C as Release.sh
    participant D as Github Action

    A->>B: Run "pnpm release"
    B->>B: Run "git tag ..." in root package
    B->>C: Run "posttag" hook

    loop release-packages
        C->>C: Run "git tag ..." in sub-package
        C->>D: Run "git push ..." in sub-package
        D->>D: Publish sub-package
    end

    C->>D: Run "git push ..." in root package
    D->>D: Publish root package
```


## Procedure
- All release should be made in `main` branch.
- Before creating a release either remote or local history should be synched.
- Every tag should be made and signed by a human, no automation allowed.
- The rest of release process after and before tagging should be automated, no human allowed.